### PR TITLE
Split componentFactory factory into own file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
+    "bel": "^3.0.0",
     "eslint-config-standard": "^4.4.0",
     "eslint-plugin-standard": "^1.3.1",
     "react": "^0.14.3",

--- a/src/componentFactory.js
+++ b/src/componentFactory.js
@@ -1,34 +1,8 @@
 import React from 'react'
-import makeGetStyleForProps from './makeGetStyleForStates'
+import factory from './factory'
 
 const identity = _ => _
 
-export const instyledWithTransform = inputTransform =>
-  (styleDefinitions, { component = 'div', name = 'instyled', staticProps = {} } = {}) => {
-    const getStyleForProps =
-      makeGetStyleForProps(inputTransform(styleDefinitions))
-
-    const Wrapper = props => {
-      const { children, mergeStyle, ...etc } = props
-      let style = getStyleForProps(etc)
-
-      if (mergeStyle != null) {
-        style = Object.assign({}, style, mergeStyle)
-      }
-
-      return React.createElement(
-        component,
-        { ...staticProps, style, ...etc },
-        children
-      )
-    }
-
-    if (name != null && typeof name === 'string') {
-      name = name[0].toUpperCase() + name.slice(1)
-      Wrapper.displayName = name
-    }
-
-    return Wrapper
-  }
+export const instyledWithTransform = factory(React.createElement)
 
 export const instyled = instyledWithTransform(identity)

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,0 +1,29 @@
+import makeGetStyleForProps from './makeGetStyleForStates'
+
+export default createElement => inputTransform =>
+  (styleDefinitions, { component = 'div', name = 'instyled', staticProps = {} } = {}) => {
+    const getStyleForProps =
+      makeGetStyleForProps(inputTransform(styleDefinitions))
+
+    const Wrapper = props => {
+      const { children, mergeStyle, ...etc } = props
+      let style = getStyleForProps(etc)
+
+      if (mergeStyle != null) {
+        style = Object.assign({}, style, mergeStyle)
+      }
+
+      return createElement(
+        component,
+        { ...staticProps, style, ...etc },
+        children
+      )
+    }
+
+    if (name != null && typeof name === 'string') {
+      name = name[0].toUpperCase() + name.slice(1)
+      Wrapper.displayName = name
+    }
+
+    return Wrapper
+  }

--- a/test/factory.js
+++ b/test/factory.js
@@ -1,0 +1,8 @@
+import create from 'bel/create'
+import factory from '../src/factory'
+import { flatKeyed } from '../src/transforms'
+
+const instyled = factory(create())(flatKeyed)
+
+// console.log(instyled(
+//   { hover: {'background-color': 'blue'}})({ hover: true }))

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,4 @@
 require('babel-core/register')
 
 require('./test.js')
+require('./factory.js')


### PR DESCRIPTION
I went for the minimum change here, so as to not disrupt any top level api. Simply adds a file that can be imported on it's own. The test is commented out because it doesn't run on node (expects a real document).
